### PR TITLE
Only generate README.py with Pandoc when creating a distro (sdist, bd…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,22 +2,27 @@
 import os, sys
 from setuptools import setup
 
-def restify():
-  if os.path.isfile('README.md'):
+def readme():
+  if os.path.isfile('README.md') and any('dist' in x for x in sys.argv[1:]):
     if os.system('pandoc -s README.md -o README.rst') != 0:
-      print('-----------------------------------------------------------')
-      print('WARNING: pandoc command failed, could not restify README.md')
-      print('-----------------------------------------------------------')
+      print('-----------------------------------------------------------------')
+      print('WARNING: README.rst could not be generated, pandoc command failed')
+      print('-----------------------------------------------------------------')
       if sys.stdout.isatty():
         input("Enter to continue... ")
-  with open('README.rst') as fp:
-    return fp.read()
+    else:
+      print("Generated README.rst with Pandoc")
+
+  if os.path.isfile('README.rst'):
+    with open('README.rst') as fp:
+      return fp.read()
+  return ''
 
 setup(
   name = "py-require",
   version = "0.17",
   description = "require() for Python",
-  long_description = restify(),
+  long_description = readme(),
   author = "Niklas Rosenstein",
   author_email = "rosensteinniklas@gmail.com",
   url = "https://github.com/NiklasRosenstein/py-require",


### PR DESCRIPTION
…ist, bdist_egg, etc.)

This would may it easier to package py-require in Conda, and then
Craftr 1.x, as discussed in a py-nr issue [1].

The `readme` function is copy-pasted from setup.py of py-nr [2].

[1] https://github.com/NiklasRosenstein/py-nr/issues/2
[2] https://github.com/NiklasRosenstein/py-nr/blob/8dd050aa2fbd0c1399203539c78fe7d0b29b6b9b/setup.py#L33-L42